### PR TITLE
Support RC-4HC

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Elitech RC4 / RC5 DataReader
 Description
 -----------
 
-This software is a data collecting tool, written in python for Temperature data logger RC-4/RC-5.
+This software is a data collecting tool, written in python for Temperature data logger RC-4/RC-5 and Temperature and Humidity data logger RC-4HC.
 
 [Elitech RC-4](http://www.elitech.uk.com/temperature_logger/Elitech_UK__Mini_USB_Temperature_Data_logger_URC_4_149.html) / 
+[RC-4HC](http://www.elitech.uk.com/temperature_logger/RC_4HC_Temperature_and_Humidity_Data_Logger_150.html) / 
 [RC-5](http://www.e-elitech.com/jingChuang3/shouYe.do?operate=doProductDetail&chanpinId=156) 
 is a reasonable data logger.
 
@@ -19,7 +20,7 @@ Requirements
 
 - Python2.7, 3.4, 3.5
 - Serial Port Driver
-    - (for RC-4) Silicon Labs CP210x USB-UART bridge VCP driver.  <http://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
+    - (for RC-4 series) Silicon Labs CP210x USB-UART bridge VCP driver.  <http://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
     - (for RC-5) CH340 Serial Driver [MacOSX](http://www.wch.cn/download/CH341SER_MAC_ZIP.html) (mac driver is unstable)
         - for sierra Signed Mac OS Driver  
             <https://blog.sengotta.net/signed-mac-os-driver-for-winchiphead-ch340-serial-bridge/>
@@ -30,7 +31,7 @@ Setup
 ------------
 
 1. Install Serial Port Driver.
-    - for RC-4: CP210x USB-UART bridge VCP driver.  Download and install CP210x driver for your platform.
+    - for RC-4 series: CP210x USB-UART bridge VCP driver.  Download and install CP210x driver for your platform.
  <http://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
     - for RC-5: CH340 Serial Driver [MacOSX](http://www.wch.cn/download/CH341SER_MAC_ZIP.html)(mac driver is unstable)
         - for sierra Signed Mac OS Driver  

--- a/rc-4-data.md
+++ b/rc-4-data.md
@@ -78,15 +78,15 @@ e   チェックサム
  ...    ...............................................
 0090    00 00 00 00 00 00 00 00 00 00 39 39 30 30 31 31
          n                          ] [o
-00A0    32 32 33 33 00 31 00 31 F1 00 00 00 00 00 00 B3
-         o        ]  p  q  r  s  t [u              ]  v
+00A0    32 32 33 33 00 31 00 31 F1 02 5D 01 31 00 0F B3
+         o        ]  p  q  r  s  t [u  ] [v  ]  w  x  y
 
 a   定数: 55
 b   station no: uint8
-c   model no? RC4:0x40  
+c   model no? RC4:0x40 RC4HC:0x2A
 d   record interval: hhmiss(time)
-e   upper limit int16 /10  0x0258 -> 600 -> 60.0
-f   lower limit int16 /10  0xFED4 -> -300 -> -30.0
+e   temperature upper limit int16 /10  0x0258 -> 600 -> 60.0
+f   temperature lower limit int16 /10  0xFED4 -> -300 -> -30.0
 g   last online time(datetime)
 h   workstatus  00:not started / 01:start / 02:stop / 03:?
 i   start time(datetime)
@@ -101,8 +101,11 @@ q   tone set 13:permit / 31:prohibit
 r   alarm 00:prohibit / 03: 3times / 0A: 10times
 s   temperature unit 13:F / 31:C
 t   temperature calibration int8 / 10
-u   padding?
-v   チェックサム
+u   humidity upper limit int16 /10  0x025D -> 605 -> 60.5
+v   humidity lower limit int16 /10  0x0131 -> 305 -> 30.5
+w   ?
+x   humidity calibration int8 / 10
+y   チェックサム
 
 ```
 
@@ -120,15 +123,15 @@ user infomationとnumberはここでは書き込まない。デバイスナン�
         -----------------------------------------------
 0000    33 02 05 00 00 00 1E 02 58 FE D4 02 13 00 31 00
          a  b [c  ] [d     ] [e  ] [f  ]  g  h  i  j  k
-0010    31 F1 00 00 00 00 00 00 EC 
-         l  m [n              ]  o
+0010    31 F1 02 58 01 2C 00 0A EC
+         l  m [n  ] [o  ]  p  q  r
 
 a   定数: 33
 b   更新前ステーション番号
 c   パラメータ設定コマンド: 0500
 d   record interval: hhmiss(time)
-e   upper limit int16 /10  0x0258 -> 600 -> 60.0
-f   lower limit int16 /10  0xFED4 -> -300 -> -30.0
+e   temperature upper limit int16 /10  0x0258 -> 600 -> 60.0
+f   temperature lower limit int16 /10  0xFED4 -> -300 -> -30.0
 g   更新後ステーション番号
 h   stop button 13:permit / 31:prohibit
 i   delaytime 00:0h / 01:0.5h / 10:1.0h / 11:1.5h / 20:2.0h / 21: 2.5h
@@ -136,7 +139,11 @@ j   tone set 13:permit / 31:prohibit
 k   alarm 00:prohibit / 03: 3times / 0A: 10times
 l   temperature unit 13:F / 31:C
 m   temperature calibration int8 / 10
-n   padding?
+n   humidity upper limit int16 /10  0x0258 -> 600 -> 60.0
+o   humidity lower limit int16 /10  0x012C -> 300 -> 30.0
+p   ?
+q   humidity calibration int8 / 10
+r   チェックサム
 ```
 
 ### レスポンス
@@ -226,9 +233,9 @@ c   チェックサム
 ```
 
 
-## 温度データ：ヘッダ取得
+## 温湿度データ：ヘッダ取得
 
-デバイスに蓄積された温度データを収集のためのヘッダ情報を取得する。
+デバイスに蓄積された温湿度データを収集のためのヘッダ情報を取得する。
 
 ヘッダ情報からデータ件数や開始時間がわかり、この後に続くボディデータの取得回数などを決定できる。
 
@@ -264,9 +271,9 @@ c   start time(datetime)
 d   チェックサム
 ```
 
-## 温度データ：ボディ取得
+## 温湿度データ：ボディ取得
 
-デバイスに蓄積された温度データを収集する。
+デバイスに蓄積された温湿度データを収集する。
 
 ヘッダ情報から決定したデータ件数を使用し、このコマンドを何度か繰り返す。
 RC-4の場合、1ページにつき最大100件のデータが取得できるので、140件のデータの場合は、ページ0(100件)、ページ1(40件)の

--- a/scripts/elitech_device.py
+++ b/scripts/elitech_device.py
@@ -57,7 +57,10 @@ def command_get(args):
 
     def output(data_list):
         for line in data_list:
-            print("{0}\t{1:%Y-%m-%d %H:%M:%S}\t{2:.1f}".format(*line))
+            if len(line) == 3:
+                print("{0}\t{1:%Y-%m-%d %H:%M:%S}\t{2:.1f}".format(*line))
+            elif len(line) == 4:
+                print("{0}\t{1:%Y-%m-%d %H:%M:%S}\t{2:.1f}\t{3:.1f}".format(*line))
 
     if args.page_size:
         device.get_data(callback=output, page_size=args.page_size)
@@ -69,10 +72,16 @@ def command_latest(args):
     device.init()
 
     def output(latest):
-        if args.value_only:
-            print("{2:.1f}".format(*latest))
-        else:
-            print("{0}\t{1:%Y-%m-%d %H:%M:%S}\t{2:.1f}".format(*latest))
+        if len(latest) == 3:
+            if args.value_only:
+                print("{2:.1f}".format(*latest))
+            else:
+                print("{2:.1f}\t{3:.1f}".format(*latest))
+        elif len(latest) == 4:
+            if args.value_only:
+                print("{0}\t{1:%Y-%m-%d %H:%M:%S}\t{2:.1f}".format(*latest))
+            else:
+                print("{0}\t{1:%Y-%m-%d %H:%M:%S}\t{2:.1f}\t{3:.1f}".format(*latest))
 
     if args.page_size:
         device.get_latest(callback=output, page_size=args.page_size)
@@ -115,6 +124,12 @@ def command_set(args):
 
     if args.temp_calibration:
         param_put.temp_calibration = float(args.temp_calibration)
+    if args.humi_upper_limit:
+        param_put.humi_upper_limit = args.humi_upper_limit
+    if args.humi_lower_limit:
+        param_put.humi_lower_limit = args.humi_lower_limit
+    if args.humi_calibration:
+        param_put.humi_calibration = float(args.humi_calibration)
     for k,v in vars(param_put).items():
         print("{}={}".format(k, v))
 
@@ -182,6 +197,9 @@ def parse_args():
     parser.add_argument('--alarm', choices=['x', '3', '10'])
     parser.add_argument('--temp_unit', choices=['C', 'F'])
     parser.add_argument('--temp_calibration', type=float)
+    parser.add_argument("--humi_upper_limit", type=float)
+    parser.add_argument("--humi_lower_limit", type=float)
+    parser.add_argument('--humi_calibration', type=float)
     parser.add_argument('--time', type=str)
     parser.add_argument('--dev_num', type=str)
     parser.add_argument('--user_info', type=str)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -79,6 +79,9 @@ class DeviceTest(unittest.TestCase):
         self.assertEqual(res.alarm, AlarmSetting.NONE)
         self.assertEqual(res.temp_unit, TemperatureUnit.C)
         self.assertEqual(res.temp_calibration, -1.5)
+        self.assertEqual(res.humi_upper_limit, 0)
+        self.assertEqual(res.humi_lower_limit, 0)
+        self.assertEqual(res.humi_calibration, 0)
 
     def test_update(self):
         device = elitech.Device(None)


### PR DESCRIPTION
[RC-4HC](http://www.elitech.uk.com/temperature_logger/RC_4HC_Temperature_and_Humidity_Data_Logger_150.html) is yet another data logger from Elitech.
It can be used for recording not only temperature but also **humidity**.

This PR implements RC-4HC support while maintaining backward compatibility.

```
$ elitech-datareader -c devinfo /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
alarm=AlarmSetting.NONE
current=2018-04-05 22:00:28
delay=0.0
dev_num=
humi_calibration=2.0
humi_lower_limit=25.5
humi_upper_limit=70.0
last_online=2018-04-05 22:00:17
lower_limit=-30.0
model_no=42
rec_count=2
rec_interval=00:00:10
start_time=2018-04-05 22:00:15
station_no=1
stop_button=StopButton.DISABLE
temp_calibration=0.0
temp_unit=TemperatureUnit.C
tone_set=ToneSet.NONE
upper_limit=60.0
user_info=RC-4HC Data Logger
work_sts=WorkStatus.START
$ elitech-datareader -c get /dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge_Controller_0001-if00-port0
1	2018-04-05 22:00:15	23.1	43.6
2	2018-04-05 22:00:25	23.1	43.6
```