### PR TITLE
Fix build for Python 3.10 by allowing PySerial version beyond 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is an unofficial tool. This tool was made by monitoring and guessing serial
 Requirements
 ------------
 
-- Python2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9
+- Python2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10
 - Serial Port Driver
     - (for RC-4 series) Silicon Labs CP210x USB-UART bridge VCP driver.  <http://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
     - (for RC-5) CH340 Serial Driver [MacOSX](http://www.wch.cn/download/CH341SER_MAC_ZIP.html) (mac driver is unstable)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 enum34==1.1.6
-pyserial==2.7
+pyserial>=2.7
 six>=1.9.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
         long_description = f.read()
 setup(
     name='elitech-datareader',
-    version='1.0.5',
+    version='1.0.6',
     packages=find_packages(),
     url='http://github.com/civic/elitech-datareader/',
     license='MIT',
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Communications',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
This fixes issue https://github.com/civic/elitech-datareader/issues/43 which previously stopped me from using this with my RC-5 unit.

Tested and this allows configuration and data download from the unit as before.